### PR TITLE
fix `RequestHandlerComponent::beforeRedirect() is deprecated` #1

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -41,7 +41,7 @@ class AppController extends Controller
     {
         parent::initialize();
 
-        $this->loadComponent('RequestHandler');
+        $this->loadComponent('RequestHandler', ['enableBeforeRedirect' => false]);
         $this->loadComponent('Flash');
 
         /*


### PR DESCRIPTION
@hashimototakuya 
AppControllerのオプションで設定可能でした。
変更点ご確認お願い致します。